### PR TITLE
Fix formatting error in the README.md

### DIFF
--- a/vim/bundle/vim-table-mode/README.md
+++ b/vim/bundle/vim-table-mode/README.md
@@ -18,8 +18,8 @@ There are several ways to do this
    add a git submodule for your plugin:
 
    ```sh
-$ cd ~/.vim
-$ git submodule add git@github.com:dhruvasagar/vim-table-mode.git bundle/table-mode
+   $ cd ~/.vim
+   $ git submodule add git@github.com:dhruvasagar/vim-table-mode.git bundle/table-mode
    ```
 3. Copy all files under autoload/, plugin/, doc/ to respective
    ~/.vim/autoload/, ~/.vim/plugin and ~/.vim/doc under UNIX or


### PR DESCRIPTION
An indentation error was present and remedied to correctly display the README in markdown.